### PR TITLE
リントエラーの修正

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,7 +1,7 @@
 import { Config, ConfigSchema } from './types';
 import { readJsonFile, resolveProjectPath } from '../utils/file';
 import { getEnv, getEnvBoolean, getEnvNumber } from '../utils/env';
-import path from 'path';
+// pathモジュールは必要ないので削除
 
 /**
  * デフォルト設定

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { loadConfig } from './config';
 import { ProxyServer } from './proxy/server';
 import { createLLMFilter } from './llm';
 
-async function main() {
+async function main(): Promise<void> {
   const config = loadConfig();
   const server = new ProxyServer(config);
 

--- a/src/llm/__mocks__/ollama.ts
+++ b/src/llm/__mocks__/ollama.ts
@@ -1,0 +1,13 @@
+// Ollamaのモッククラス
+export class Ollama {
+  constructor(_options: Record<string, unknown>) {
+    // コンストラクタのモック
+  }
+
+  // generateメソッドのモック
+  async generate(_params: Record<string, unknown>): Promise<{ response: string }> {
+    return {
+      response: 'フィルタリングされたコンテンツ',
+    };
+  }
+}

--- a/src/llm/__mocks__/ollama.ts
+++ b/src/llm/__mocks__/ollama.ts
@@ -5,7 +5,9 @@ export class Ollama {
   }
 
   // generateメソッドのモック
-  async generate(_params: Record<string, unknown>): Promise<{ response: string }> {
+  async generate(
+    _params: Record<string, unknown>,
+  ): Promise<{ response: string }> {
     return {
       response: 'フィルタリングされたコンテンツ',
     };

--- a/src/llm/__tests__/index.test.ts
+++ b/src/llm/__tests__/index.test.ts
@@ -6,8 +6,8 @@ jest.mock('../ollama', () => {
   return {
     OllamaFilter: jest.fn().mockImplementation(() => ({
       name: 'OllamaFilter',
-      filter: jest.fn().mockResolvedValue('フィルタリングされたコンテンツ')
-    }))
+      filter: jest.fn().mockResolvedValue('フィルタリングされたコンテンツ'),
+    })),
   };
 });
 
@@ -15,14 +15,15 @@ jest.mock('../openrouter', () => {
   return {
     OpenRouterFilter: jest.fn().mockImplementation(() => ({
       name: 'OpenRouterFilter',
-      filter: jest.fn().mockResolvedValue('フィルタリングされたコンテンツ')
-    }))
+      filter: jest.fn().mockResolvedValue('フィルタリングされたコンテンツ'),
+    })),
   };
 });
 
 // モックを取得
 const { OllamaFilter: mockOllamaFilter } = jest.requireMock('../ollama');
-const { OpenRouterFilter: mockOpenRouterFilter } = jest.requireMock('../openrouter');
+const { OpenRouterFilter: mockOpenRouterFilter } =
+  jest.requireMock('../openrouter');
 
 describe('LLMフィルターファクトリー', () => {
   let config: Config;

--- a/src/llm/__tests__/ollama.test.ts
+++ b/src/llm/__tests__/ollama.test.ts
@@ -10,12 +10,12 @@ jest.mock('ollama', () => {
           return {
             message: {
               role: 'assistant',
-              content: 'フィルタリングされたコンテンツ'
-            }
+              content: 'フィルタリングされたコンテンツ',
+            },
           };
-        })
+        }),
       };
-    })
+    }),
   };
 });
 
@@ -53,9 +53,9 @@ describe('OllamaFilter', () => {
         error: jest.fn(),
         info: jest.fn(),
         debug: jest.fn(),
-        warn: jest.fn()
+        warn: jest.fn(),
       } as any,
-      ignoreRobotsTxt: false
+      ignoreRobotsTxt: false,
     };
 
     // モックをリセット
@@ -70,37 +70,37 @@ describe('OllamaFilter', () => {
   test('LLMが無効の場合は元のコンテンツが返される', async () => {
     const disabledConfig = { ...config };
     disabledConfig.llm.enabled = false;
-    
+
     const filter = new OllamaFilter(disabledConfig);
     const result = await filter.filter('テストコンテンツ', context);
-    
+
     expect(result).toBe('テストコンテンツ');
   });
 
   test('フィルターが正しくコンテンツをフィルタリングする', async () => {
     const filter = new OllamaFilter(config);
     const result = await filter.filter('テストコンテンツ', context);
-    
+
     expect(result).toBe('フィルタリングされたコンテンツ');
   });
 
   test('LLMが無効の場合は元のコンテンツが返される', async () => {
     const disabledConfig = { ...config };
     disabledConfig.llm.enabled = false;
-    
+
     const filter = new OllamaFilter(disabledConfig);
     const result = await filter.filter('テストコンテンツ', context);
-    
+
     expect(result).toBe('テストコンテンツ');
   });
 
   test('カスタムベースURLを使用する', async () => {
     const customConfig = { ...config };
     customConfig.llm.baseUrl = 'http://custom-ollama:11434';
-    
+
     const filter = new OllamaFilter(customConfig);
     const result = await filter.filter('テストコンテンツ', context);
-    
+
     expect(result).toBe('フィルタリングされたコンテンツ');
   });
 
@@ -109,13 +109,13 @@ describe('OllamaFilter', () => {
     const { Ollama } = require('ollama');
     Ollama.mockImplementation(() => {
       return {
-        chat: jest.fn().mockRejectedValue(new Error('テストエラー'))
+        chat: jest.fn().mockRejectedValue(new Error('テストエラー')),
       };
     });
-    
+
     const filter = new OllamaFilter(config);
     const result = await filter.filter('テストコンテンツ', context);
-    
+
     // エラー時は元のコンテンツが返される
     expect(result).toBe('テストコンテンツ');
     // ロガーがエラーを記録したことを確認

--- a/src/llm/__tests__/openrouter.test.ts
+++ b/src/llm/__tests__/openrouter.test.ts
@@ -56,9 +56,9 @@ describe('OpenRouterFilter', () => {
         error: jest.fn(),
         info: jest.fn(),
         debug: jest.fn(),
-        warn: jest.fn()
+        warn: jest.fn(),
       } as any,
-      ignoreRobotsTxt: false
+      ignoreRobotsTxt: false,
     };
   });
 
@@ -70,7 +70,7 @@ describe('OpenRouterFilter', () => {
   test('APIキーが設定されていない場合はエラーがスローされる', () => {
     const invalidConfig = { ...config };
     invalidConfig.llm.apiKey = '';
-    
+
     expect(() => {
       new OpenRouterFilter(invalidConfig);
     }).toThrow('OpenRouterフィルターにはAPIキーが必要です');
@@ -79,17 +79,17 @@ describe('OpenRouterFilter', () => {
   test('LLMが無効の場合は元のコンテンツが返される', async () => {
     const disabledConfig = { ...config };
     disabledConfig.llm.enabled = false;
-    
+
     const filter = new OpenRouterFilter(disabledConfig);
     const result = await filter.filter('テストコンテンツ', context);
-    
+
     expect(result).toBe('テストコンテンツ');
   });
 
   test('フィルターが正しくコンテンツをフィルタリングする', async () => {
     const filter = new OpenRouterFilter(config);
     const result = await filter.filter('テストコンテンツ', context);
-    
+
     expect(result).toBe('フィルタリングされたコンテンツ');
   });
 });

--- a/src/llm/openrouter.ts
+++ b/src/llm/openrouter.ts
@@ -20,8 +20,8 @@ export class OpenRouterFilter implements ContentFilter {
       apiKey: config.llm.apiKey,
       baseURL: baseURL,
       defaultHeaders: {
-        'HTTP-Referer': 'https://github.com/GOROman/SubtractProxy', // アプリケーションのURL
-        'X-Title': 'SubtractProxy', // アプリケーション名
+        'HTTP-Referer': 'https://github.com/GOROman/SubtractProxy', // URL
+        'X-Title': 'SubtractProxy', // アプリ名
       },
     });
   }

--- a/src/proxy/__tests__/server.test.ts
+++ b/src/proxy/__tests__/server.test.ts
@@ -13,8 +13,8 @@ jest.mock('../../utils/logger', () => ({
     info: jest.fn(),
     error: jest.fn(),
     debug: jest.fn(),
-    warn: jest.fn()
-  })
+    warn: jest.fn(),
+  }),
 }));
 
 describe('プロキシサーバー', () => {
@@ -39,8 +39,8 @@ describe('プロキシサーバー', () => {
         baseUrl: 'http://localhost:11434',
       },
       logging: {
-        level: 'info'
-      }
+        level: 'info',
+      },
     } as Config;
 
     // モックの作成
@@ -49,7 +49,7 @@ describe('プロキシサーバー', () => {
       listen: jest.fn().mockImplementation((port, host, callback) => {
         if (callback) callback();
         return mockApp;
-      })
+      }),
     };
 
     mockProxy = {
@@ -59,9 +59,11 @@ describe('プロキシサーバー', () => {
 
     mockFilter = {
       name: 'TestFilter',
-      filter: jest.fn().mockImplementation((content) => 
-        Promise.resolve('フィルタリングされたコンテンツ')
-      ),
+      filter: jest
+        .fn()
+        .mockImplementation((content) =>
+          Promise.resolve('フィルタリングされたコンテンツ'),
+        ),
     };
 
     // モックの設定
@@ -75,27 +77,27 @@ describe('プロキシサーバー', () => {
 
     // Expressアプリが作成されたか確認
     expect(express).toHaveBeenCalled();
-    
+
     // プロキシが作成されたか確認
     expect(httpProxy.createProxyServer).toHaveBeenCalled();
   });
 
   test('プロキシサーバーがリクエストを正しく処理する', () => {
     const server = new ProxyServer(config);
-    
+
     // app.useが呼ばれたか確認
     expect(mockApp.use).toHaveBeenCalled();
-    
+
     // useのコールバックを取得
     const useCallback = mockApp.use.mock.calls[0][1];
-    
+
     // リクエストとレスポンスをモック
     const req = { url: 'http://example.com' };
     const res = {};
-    
+
     // コールバックを実行
     useCallback(req, res);
-    
+
     // proxy.webが正しく呼ばれたか確認
     expect(mockProxy.web).toHaveBeenCalledWith(req, res, {
       target: req.url,
@@ -106,47 +108,50 @@ describe('プロキシサーバー', () => {
   test('proxyReqイベントが正しく処理される', () => {
     // ignoreRobotsTxtをtrueに設定
     config.ignoreRobotsTxt = true;
-    
+
     const server = new ProxyServer(config);
-    
+
     // proxyReqイベントハンドラを取得
     const proxyReqHandler = mockProxy.on.mock.calls.find(
-      (call: any[]) => call[0] === 'proxyReq'
+      (call: any[]) => call[0] === 'proxyReq',
     )[1];
-    
+
     // リクエストをモック
     const proxyReq = { setHeader: jest.fn() };
     const req = {};
     const res = {};
-    
+
     // ハンドラを実行
     proxyReqHandler(proxyReq, req, res);
-    
+
     // User-Agentヘッダーが設定されたか確認
-    expect(proxyReq.setHeader).toHaveBeenCalledWith('User-Agent', 'SubtractProxy/1.0');
+    expect(proxyReq.setHeader).toHaveBeenCalledWith(
+      'User-Agent',
+      'SubtractProxy/1.0',
+    );
   });
 
   test('proxyResイベントの登録が正しく行われる', () => {
     const server = new ProxyServer(config);
-    
+
     // proxyResイベントが登録されたか確認
     expect(mockProxy.on).toHaveBeenCalledWith('proxyRes', expect.any(Function));
   });
 
   test('フィルターの追加が正しく動作する', () => {
     const server = new ProxyServer(config);
-    
+
     // フィルターを追加
     server.addFilter(mockFilter);
-    
+
     // フィルターが追加されたか確認する方法がないので、
     // フィルターの動作をテストする
-    
+
     // proxyResイベントハンドラを取得
     const proxyResHandler = mockProxy.on.mock.calls.find(
-      (call: any[]) => call[0] === 'proxyRes'
+      (call: any[]) => call[0] === 'proxyRes',
     )[1];
-    
+
     // レスポンスをモック
     const proxyRes = {
       on: jest.fn().mockImplementation((event, callback) => {
@@ -159,28 +164,28 @@ describe('プロキシサーバー', () => {
         return proxyRes;
       }),
     };
-    
+
     const req = {};
     const res = { end: jest.fn() };
-    
+
     // ハンドラを実行
     proxyResHandler(proxyRes, req, res);
-    
+
     // フィルターが呼ばれたか確認
     expect(mockFilter.filter).toHaveBeenCalled();
   });
 
   test('サーバーが正しく起動する', () => {
     const server = new ProxyServer(config);
-    
+
     // サーバーを起動
     server.start();
-    
+
     // listenが正しく呼ばれたか確認
     expect(mockApp.listen).toHaveBeenCalledWith(
       config.port,
       config.host,
-      expect.any(Function)
+      expect.any(Function),
     );
   });
 
@@ -189,7 +194,7 @@ describe('プロキシサーバー', () => {
 
     // proxyResイベントが設定されたか確認
     expect(mockProxy.on).toHaveBeenCalledWith('proxyRes', expect.any(Function));
-    
+
     // proxyReqイベントが設定されたか確認
     expect(mockProxy.on).toHaveBeenCalledWith('proxyReq', expect.any(Function));
   });
@@ -203,7 +208,7 @@ describe('プロキシサーバー', () => {
     expect(mockApp.listen).toHaveBeenCalledWith(
       config.port,
       config.host,
-      expect.any(Function)
+      expect.any(Function),
     );
   });
 });

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -18,16 +18,16 @@ export class ProxyServer {
   }
 
   private setupProxy() {
-    this.proxy.on('proxyReq', (proxyReq, req, res) => {
+    this.proxy.on('proxyReq', (proxyReq, req, res): void => {
       if (this.config.ignoreRobotsTxt) {
         proxyReq.setHeader('User-Agent', 'SubtractProxy/1.0');
       }
     });
 
-    this.proxy.on('proxyRes', async (proxyRes, req, res) => {
+    this.proxy.on('proxyRes', async (proxyRes, req, res): Promise<void> => {
       const context: ProxyContext = {
-        req: req as any,
-        res: res as any,
+        req: req as express.Request,
+        res: res as express.Response,
         logger: this.logger,
         ignoreRobotsTxt: this.config.ignoreRobotsTxt,
       };
@@ -54,7 +54,7 @@ export class ProxyServer {
       });
     });
 
-    this.app.use('/', (req, res) => {
+    this.app.use('/', (req, res): void => {
       this.proxy.web(req, res, {
         target: req.url,
         changeOrigin: true,
@@ -62,13 +62,13 @@ export class ProxyServer {
     });
   }
 
-  public addFilter(filter: ContentFilter) {
+  public addFilter(filter: ContentFilter): void {
     this.filters.push(filter);
     this.logger.info(`フィルター追加: ${filter.name}`);
   }
 
-  public start() {
-    this.app.listen(this.config.port, this.config.host, () => {
+  public start(): void {
+    this.app.listen(this.config.port, this.config.host, (): void => {
       this.logger.info(
         `プロキシサーバーが起動しました - http://${this.config.host}:${this.config.port}`,
       );

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -17,8 +17,8 @@ export class ProxyServer {
     this.setupProxy();
   }
 
-  private setupProxy() {
-    this.proxy.on('proxyReq', (proxyReq, req, res): void => {
+  private setupProxy(): void {
+    this.proxy.on('proxyReq', (proxyReq, _req, _res): void => {
       if (this.config.ignoreRobotsTxt) {
         proxyReq.setHeader('User-Agent', 'SubtractProxy/1.0');
       }

--- a/src/utils/__tests__/logger.test.ts
+++ b/src/utils/__tests__/logger.test.ts
@@ -47,8 +47,8 @@ describe('ロガー', () => {
         model: 'gemma',
       },
       logging: {
-        level: 'info'
-      }
+        level: 'info',
+      },
     } as Config;
   });
 
@@ -63,7 +63,7 @@ describe('ロガー', () => {
   test('ファイルロギングが設定されている場合', () => {
     const configWithFile = { ...config };
     configWithFile.logging.file = 'logs/app.log';
-    
+
     createLogger(configWithFile);
     expect(winston.transports.File).toHaveBeenCalledWith({
       filename: configWithFile.logging.file,
@@ -77,7 +77,7 @@ describe('ロガー', () => {
     expect(winston.createLogger).toHaveBeenCalledWith(
       expect.objectContaining({
         level: 'debug',
-      })
+      }),
     );
   });
 });

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,7 +1,7 @@
 import winston from 'winston';
 import { Config } from '../config';
 
-export const createLogger = (config: Config) => {
+export const createLogger = (config: Config): winston.Logger => {
   const transports: winston.transport[] = [
     new winston.transports.Console({
       format: winston.format.combine(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
     }
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## 概要

ESLintのエラーと警告を修正しました。

## 変更内容

- tsconfig.jsonからテストファイルの除外設定を削除
- 関数の戻り値型を明示的に指定
- 未使用の引数名の先頭にアンダースコアを追加
- anyタイプの代わりにRecord<string, unknown>を使用
- モックファイルの型定義を改善

## テスト

- ESLintのチェックが正常に通過することを確認